### PR TITLE
Python Script link is broken in https://docs.microsoft.com/en-us/samples/azure-samples/jmeter-aci-terraform/jmeter-aci-terraform/?source=docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Or even use the UI to define variables and Run the pipeline:
 
 ## Viewing Test Results
 
-JMeter test results are created in a [JTL](https://cwiki.apache.org/confluence/display/JMETER/JtlFiles) file (`results.jtl`) with CSV formatting. A [Python script](./scripts/jtl_junit_converter.py) was created to convert JTL to [JUnit format](https://llg.cubic.org/docs/junit/) and used during the pipeline to have full integration with Azure DevOps test visualization.
+JMeter test results are created in a [JTL](https://cwiki.apache.org/confluence/display/JMETER/JtlFiles) file (`results.jtl`) with CSV formatting. A [Python script](https://github.com/Azure-Samples/jmeter-aci-terraform/blob/main/scripts/jtl_junit_converter.py) was created to convert JTL to [JUnit format](https://llg.cubic.org/docs/junit/) and used during the pipeline to have full integration with Azure DevOps test visualization.
 
 ![Azure DevOps with successful requests](./docs/img/azdo-test-results-success.jpg)
 


### PR DESCRIPTION
Python Script link is broken in the document:

https://docs.microsoft.com/en-us/samples/azure-samples/jmeter-aci-terraform/jmeter-aci-terraform/?source=docs

Fixing the link.

fixes #52 