### PR TITLE
Teardown step should be always executed

### DIFF
--- a/pipelines/azure-pipelines.load-test.yml
+++ b/pipelines/azure-pipelines.load-test.yml
@@ -134,5 +134,6 @@ steps:
   displayName: 'RESULTS: Publish Load Test Artifacts'
 
 - script: terraform destroy -auto-approve
+  condition: always()
   workingDirectory: ./terraform
   displayName: 'TEARDOWN: Run Terraform Destroy'


### PR DESCRIPTION
Teardown step is important for the pipeline and should be always executed if we face some error in the test execution or some timeout error we need to clean resources that the pipeline created.