### PR TITLE
Fix for Issue #46

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_subnet" "jmeter_subnet" {
   name                 = "${var.PREFIX}subnet"
   resource_group_name  = azurerm_resource_group.jmeter_rg.name
   virtual_network_name = azurerm_virtual_network.jmeter_vnet.name
-  address_prefix       = var.SUBNET_ADDRESS_PREFIX
+  address_prefixes     = ["${var.SUBNET_ADDRESS_PREFIX}"]
 
   delegation {
     name = "delegation"


### PR DESCRIPTION
Terraform warns of deprecation address_prefix and recommends moving to address_prefixes
fix #46 